### PR TITLE
config: exclude uncompressed assets

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -17,9 +17,6 @@ config.google_drive.sheets_folder_ids = [
 
 config.google_drive.assets_folder_ids = ["1abaL1QGd33NqqLoKuo2t9fVWKmh5ouM9", "1kLl5t3o4A2ssC2iC-lT2bp4u8BZZneSE"];
 
-// Exclude uncompressed assets
-config.app_data.assets_filter_function = (fileEntry) => !fileEntry.relativePath.includes("uncompressed")
-
 config.api.db_name = "plh_kids_tz";
 
 // Hacky fix to point extended deployment to translations within its own repo
@@ -28,8 +25,8 @@ config.translations.translated_strings_path = "./app_data/translations_source/tr
 // Hacky fix to point extended deployment to content within its own repo
 config.app_data.output_path = "./app_data";
 
-// Exclude draft assets to reduce app size
-config.app_data.assets_filter_function = (fileEntry) => !fileEntry.relativePath.includes("draft")
+// To reduce app size, exclude draft and uncompressed assets
+config.app_data.assets_filter_function = (fileEntry) => !fileEntry.relativePath.includes("draft") && !fileEntry.relativePath.includes("uncompleted")
 
 config.app_config.APP_LANGUAGES.default = "gb_en";
 config.app_config.APP_SIDEMENU_DEFAULTS.title = "ParentApp for Kids TZ";

--- a/config.ts
+++ b/config.ts
@@ -5,7 +5,7 @@ const config = extendDeploymentConfig({ name: "plh_kids_tz", parent: "plh_kids" 
 
 config.git = {
   content_repo: "https://github.com/IDEMSInternational/plh-kids-app-tz-content.git",
-  content_tag_latest: "1.1.65",
+  content_tag_latest: "1.1.67",
 };
 
 config.google_drive.sheets_folder_ids = [
@@ -16,6 +16,9 @@ config.google_drive.sheets_folder_ids = [
 ];
 
 config.google_drive.assets_folder_ids = ["1abaL1QGd33NqqLoKuo2t9fVWKmh5ouM9", "1kLl5t3o4A2ssC2iC-lT2bp4u8BZZneSE"];
+
+// Exclude uncompressed assets
+config.app_data.assets_filter_function = (fileEntry) => !fileEntry.relativePath.includes("uncompressed")
 
 config.api.db_name = "plh_kids_tz";
 


### PR DESCRIPTION
Updates deployment config to exclude asset files that sit in folders with the name "uncompressed" on Google Drive. See https://github.com/IDEMSInternational/open-app-builder/pull/1994 for the first use of this pattern